### PR TITLE
Fix Powershell in CMD being mis-detected

### DIFF
--- a/libmachine/shell/shell_windows.go
+++ b/libmachine/shell/shell_windows.go
@@ -52,7 +52,9 @@ func getNameAndItsPpid(pid int) (exefile string, parentid int, err error) {
 func Detect() (string, error) {
 	shell := os.Getenv("SHELL")
 
-	if shell == "" {
+	// if you spawn a Powershell instance from CMD, sometimes the SHELL environment variable still points to CMD in the Powershell instance
+	// so if SHELL is pointing to CMD, let's do extra work to get the correct shell
+	if shell == "" || filepath.Base(shell) == "cmd" {
 		shell, shellppid, err := getNameAndItsPpid(os.Getppid())
 		if err != nil {
 			return "cmd", err // defaulting to cmd


### PR DESCRIPTION
## Description
If you spawn a Powershell instance from CMD, sometimes the SHELL environment variable still points to CMD in the Powershell instance. So if SHELL is pointing to CMD, let's do extra work to get the correct shell.